### PR TITLE
bugfix

### DIFF
--- a/cdbwalk.py
+++ b/cdbwalk.py
@@ -135,7 +135,7 @@ while True:  # if args.forever is true, run indefinitely; o/w stop after one run
         if verbose >= 2:
             print(f"\n  Ply queued for analysis: {ply}", end="")
         bt = 0
-        while bt < args.backtrack and bt < ply:
+        while bt < args.backtrack and board.move_stack:
             cdb.queue(board.epd())
             board.pop()
             bt += 1


### PR DESCRIPTION
This fixes a bug where the move_stack of `board` is empty for fens with black to move and `--backtrack` larger than the walk.