### PR TITLE
by default do not walk in 7men land

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,7 @@ options:
                         The number of plies to walk back from the newly created leaf towards the root, queuing each position on the way for analysis. (default: 0)
   --depthLimit DEPTHLIMIT
                         The upper limit of plies the walk is allowed to last. (default: 200)
+  --TBwalk              Continue the walk in 7men EGTB land. (default: False)
   --forever             Run the script in an infinite loop. (default: False)
 ```
 

--- a/cdbwalk.py
+++ b/cdbwalk.py
@@ -60,6 +60,11 @@ parser.add_argument(
     default=200,
 )
 parser.add_argument(
+    "--TBwalk",
+    action="store_true",
+    help="Continue the walk in 7men EGTB land.",
+)
+parser.add_argument(
     "--forever",
     action="store_true",
     help="Run the script in an infinite loop.",
@@ -128,6 +133,13 @@ while True:  # if args.forever is true, run indefinitely; o/w stop after one run
                 r = {}
                 if verbose:
                     print("1/2 - 1/2", end="")
+            elif (
+                not args.TBwalk
+                and (pc := sum(p in "pnbrqk" for p in board.epd().lower())) <= 7
+            ):
+                r = {}
+                if verbose:
+                    print(f"{pc}men EGTB")
             else:
                 r = cdb.queryall(board.epd())
         if verbose >= 3:


### PR DESCRIPTION
This fixed an undesirable behaviour in main, which can lead to (long) walks in the 7men EGTBs. New default behaviour is to stop such walks immediately, as 7men positions are not stored as nodes on cdb, and so continuing these walks does not improve cdb at all.