### PR TITLE
Replace --forever by --loops/-l option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ git clone https://github.com/robertnurnberg/cdblib && pip install -r cdblib/requ
 A command line program to walk within the tree of cdb, starting either from a list of FENs or from the (opening) lines given in a PGN file, possibly extending each explored line within cdb by one ply.
 
 ```
-usage: cdbwalk.py [-h] [-v] [--moveTemp MOVETEMP] [--backtrack BACKTRACK] [--depthLimit DEPTHLIMIT] [--TBwalk] [-c CONCURRENCY] [-b BATCHSIZE] [-u USER] [-s] [--forever] filename
+usage: cdbwalk.py [-h] [-v] [--moveTemp MOVETEMP] [--backtrack BACKTRACK] [--depthLimit DEPTHLIMIT] [--TBwalk] [-c CONCURRENCY] [-b BATCHSIZE] [-u USER] [-s] [-loops LOOPS | --forever] filename
 
 A script that walks within the chessdb.cn tree, starting from FENs or lines in a PGN file. Based on the given parameters, the script selects a move in each node, walking towards the leafs. Once an unknown position is reached, it is queued for analysis and the walk terminates.
 
@@ -58,7 +58,11 @@ options:
                         Number of positions processed in parallel. Small values guarantee more responsive output, large values give faster turnaround. (default: None)
   -u USER, --user USER  Add this username to the http user-agent header. (default: None)
   -s, --suppressErrors  Suppress error messages from cdblib. (default: False)
+  -l LOOPS, --loops LOOPS
+                        Run the scripts for N passes (default 1)
   --forever             Run the script in an infinite loop. (default: False)
+  
+Note: --loops and --forever are mutually exclusive.
 ```
 
 Sample usage and output:

--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ git clone https://github.com/robertnurnberg/cdblib && pip install -r cdblib/requ
 A command line program to walk within the tree of cdb, starting either from a list of FENs or from the (opening) lines given in a PGN file, possibly extending each explored line within cdb by one ply.
 
 ```
-usage: cdbwalk.py [-h] [-v] [--moveTemp MOVETEMP] [--backtrack BACKTRACK] [--depthLimit DEPTHLIMIT] [--TBwalk] [-c CONCURRENCY] [-b BATCHSIZE] [-u USER] [-s] [-loops LOOPS | --forever] filename
+usage: cdbwalk.py [-h] [-v] [--moveTemp MOVETEMP] [--backtrack BACKTRACK] [--depthLimit DEPTHLIMIT] [--TBwalk] [-c CONCURRENCY] [-b BATCHSIZE] [-u USER] [-s] [-l LOOPS | --forever] filename
 
 A script that walks within the chessdb.cn tree, starting from FENs or lines in a PGN file. Based on the given parameters, the script selects a move in each node, walking towards the leafs. Once an unknown position is reached, it is queued for analysis and the walk terminates.
 
@@ -59,10 +59,8 @@ options:
   -u USER, --user USER  Add this username to the http user-agent header. (default: None)
   -s, --suppressErrors  Suppress error messages from cdblib. (default: False)
   -l LOOPS, --loops LOOPS
-                        Run the scripts for N passes (default 1)
+                        Run the script for N passes. (default: 1)
   --forever             Run the script in an infinite loop. (default: False)
-  
-Note: --loops and --forever are mutually exclusive.
 ```
 
 Sample usage and output:

--- a/cdbwalk.py
+++ b/cdbwalk.py
@@ -1,7 +1,7 @@
 """
    Script that makes chessdb.cn explore certain openings or book exits.
 """
-import argparse, asyncio, math, random, time, chess, chess.pgn, cdblib
+import argparse, asyncio, itertools, math, random, time, chess, chess.pgn, cdblib
 
 
 def select_move(movelist, temp):
@@ -230,10 +230,7 @@ async def main():
     )
     lf = parser.add_mutually_exclusive_group(required=False)
     lf.add_argument(
-        "-l", "--loops",
-        type=int,
-        help="Run the scripts for N passes.",
-        default=1
+        "-l", "--loops", type=int, help="Run the script for N passes.", default=1
     )
     lf.add_argument(
         "--forever",
@@ -257,14 +254,10 @@ async def main():
     if args.loops <= 0:
         parser.error("--loops must be a positive integer")
 
-    if args.forever:
-        while True:
-            walk.reload()
-            await walk.parse_all(args.batchSize)
-    else:
-        for _ in range(args.loops):
-            walk.reload()
-            await walk.parse_all(args.batchSize)
+    for _ in itertools.count() if args.forever else range(args.loops):
+        # re-reading the data in each loop allows updates to it in the background
+        walk.reload()
+        await walk.parse_all(args.batchSize)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **What**

Add --loops (short -l) to control how many loops the script runs.

Accepts a positive integer or the word forever (unlimited).

Default remains 1; no other behavior changes.

Remove --forever (small breaking change).

### **Why**

Finite loops will now be available instead of just only having the forever option. This allows to make scripts where they run X amount of loops and then use the data of all the PGN's if -v is used.

### **How**

_parse_loops() parses 'forever' → math.inf or validates a positive integer.

The main loop counts passes and stops when count >= loops (unless loops is infinite).

### **Usage**

**1 run (default)**

`python cdbwalk.py -v FILENAME`

**exactly 3 runs**

```
python cdbwalk.py -v -l 3 FILENAME
python cdbwalk.py -v --loops 3 FILENAME
```

**infinite runs)**

```
python cdbwalk.py -v -l forever FILENAME
python cdbwalk.py -v --loops forever FILENAME
```


_If existing scripts rely on --forever, you can reintroduce a deprecated flag:_
_Add this argparser after the --loops argument):_
```
parser.add_argument(
    "--forever",
    action="store_true",
    help=argparse.SUPPRESS,  # deprecated; retained for compatibility
)

```
_Also add this after the parsing before you use loops_
```
if args.forever:
    loops = math.inf
```